### PR TITLE
fix: add default schemas for manual shopify schemas

### DIFF
--- a/schemas/shopify/webhooks/2022-01/Customer.json
+++ b/schemas/shopify/webhooks/2022-01/Customer.json
@@ -35,7 +35,10 @@
             "description": "The customer's phone number at this address."
           },
           "company": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "The customer's company."
           },
           "country": {
@@ -117,7 +120,10 @@
           "description": "The customer's phone number at this address."
         },
         "company": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "The customer's company."
         },
         "country": {
@@ -334,5 +340,81 @@
   },
   "required": [
     "id"
-  ]
+  ],
+  "default": {
+    "accepts_marketing": false,
+    "accepts_marketing_updated_at": "2013-06-27T08:48:27-04:00",
+    "addresses": [
+      {
+        "id": 207119551,
+        "zip": "40202",
+        "city": "Louisville",
+        "phone": "555-625-1199",
+        "company": null,
+        "country": "United States",
+        "default": true,
+        "address1": "Chestnut Street 92",
+        "address2": "Apartment 2",
+        "province": "Kentucky",
+        "last_name": "Norman",
+        "first_name": "Bob",
+        "customer_id": 6940095564,
+        "country_code": "US",
+        "country_name": "United States",
+        "province_code": "KY"
+      }
+    ],
+    "currency": "JPY",
+    "created_at": "2013-06-27T08:48:27-04:00",
+    "default_address": {
+      "id": 207119551,
+      "zip": "40202",
+      "city": "Louisville",
+      "phone": "555-625-1199",
+      "company": null,
+      "country": "united states",
+      "default": true,
+      "address1": "Chestnut Street 92",
+      "address2": "Apartment 2",
+      "province": "Kentucky",
+      "last_name": "Norman",
+      "first_name": "Bob",
+      "country_code": "US",
+      "country_name": "United States",
+      "province_code": "KY"
+    },
+    "email": "bob.norman@hostmail.com",
+    "first_name": "John",
+    "id": 207119551,
+    "last_name": "Norman",
+    "last_order_id": 234132602919,
+    "last_order_name": "#1169",
+    "metafield": {
+      "key": "new",
+      "type": "string",
+      "value": "newvalue",
+      "namespace": "global"
+    },
+    "marketing_opt_in_level": "single_opt_in",
+    "multipass_identifier": null,
+    "note": "Placed an order that had a fraud warning",
+    "orders_count": 3,
+    "phone": "+16135551111",
+    "sms_marketing_consent": {
+      "state": "subscribed",
+      "opt_in_level": "single_opt_in",
+      "consent_updated_at": "2021-08-03T15:31:06-04:00",
+      "consent_collected_from": "OTHER"
+    },
+    "state": "disabled",
+    "tags": "loyal",
+    "tax_exempt": true,
+    "tax_exemptions": [
+      "CA_STATUS_CARD_EXEMPTION",
+      "CA_BC_RESELLER_EXEMPTION"
+    ],
+    "total_spent": "375.30",
+    "updated_at": "2012-08-24T14:01:46-04:00",
+    "verified_email": true
+  }
 }

--- a/schemas/shopify/webhooks/2022-01/Order.json
+++ b/schemas/shopify/webhooks/2022-01/Order.json
@@ -25,7 +25,10 @@
           "description": "The customer's phone number at this address."
         },
         "company": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "The customer's company."
         },
         "country": {
@@ -1082,7 +1085,10 @@
           "description": "The customer's phone number at this address."
         },
         "company": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "The customer's company."
         },
         "country": {
@@ -1476,6 +1482,520 @@
           "description": "The URL pointing to the order status web page, if applicable."
         }
       }
+    }
+  },
+  "default": {
+    "app_id": 1966818,
+    "billing_address": {
+      "zip": "T0E 0M0",
+      "city": "Drayton Valley",
+      "name": "Christopher Gorski",
+      "phone": "(555)555-5555",
+      "company": null,
+      "country": "Canada",
+      "address1": "2259 Park Ct",
+      "address2": "Apartment 5",
+      "latitude": "45.41634",
+      "province": "Alberta",
+      "last_name": "Gorski",
+      "longitude": "-75.6868",
+      "first_name": "Christopher",
+      "country_code": "CA",
+      "province_code": "AB"
+    },
+    "browser_ip": "216.191.105.146",
+    "buyer_accepts_marketing": false,
+    "cancel_reason": "customer",
+    "cancelled_at": null,
+    "cart_token": "68778783ad298f1c80c3bafcddeea",
+    "checkout_token": "bd5a8aa1ecd019dd3520ff791ee3a24c",
+    "client_details": {
+      "browser_ip": "216.191.105.146",
+      "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36",
+      "session_hash": "9ad4d1f4e6a8977b9dd98eed1e477643",
+      "browser_width": 1280,
+      "browser_height": 1320,
+      "accept_language": "en-US,en;q=0.9"
+    },
+    "closed_at": "2008-01-10T11:00:00-05:00",
+    "created_at": "2008-01-10T11:00:00-05:00",
+    "currency": "USD",
+    "current_total_discounts": "10.00",
+    "current_total_discounts_set": {
+      "current_total_discounts_set": {
+        "shop_money": {
+          "amount": "10.00",
+          "currency_code": "CAD"
+        },
+        "presentment_money": {
+          "amount": "5.00",
+          "currency_code": "EUR"
+        }
+      }
+    },
+    "current_total_duties_set": {
+      "current_total_duties_set": {
+        "shop_money": {
+          "amount": "164.86",
+          "currency_code": "CAD"
+        },
+        "presentment_money": {
+          "amount": "105.31",
+          "currency_code": "EUR"
+        }
+      }
+    },
+    "current_total_price": "10.00",
+    "current_total_price_set": {
+      "current_total_price_set": {
+        "shop_money": {
+          "amount": "30.00",
+          "currency_code": "CAD"
+        },
+        "presentment_money": {
+          "amount": "20.00",
+          "currency_code": "EUR"
+        }
+      }
+    },
+    "current_subtotal_price": "10.00",
+    "current_subtotal_price_set": {
+      "current_subtotal_price_set": {
+        "shop_money": {
+          "amount": "30.00",
+          "currency_code": "CAD"
+        },
+        "presentment_money": {
+          "amount": "20.00",
+          "currency_code": "EUR"
+        }
+      }
+    },
+    "current_total_tax": "10.00",
+    "current_total_tax_set": {
+      "current_total_tax_set": {
+        "shop_money": {
+          "amount": "30.00",
+          "currency_code": "CAD"
+        },
+        "presentment_money": {
+          "amount": "20.00",
+          "currency_code": "EUR"
+        }
+      }
+    },
+    "customer": {
+      "id": 207119551,
+      "note": null,
+      "tags": "loyal",
+      "email": "bob.norman@hostmail.com",
+      "phone": "+13125551212",
+      "state": "disabled",
+      "currency": "USD",
+      "addresses": {},
+      "last_name": "Norman",
+      "created_at": "2012-03-13T16:09:55-04:00",
+      "first_name": "Bob",
+      "tax_exempt": false,
+      "updated_at": "2012-03-13T16:09:55-04:00",
+      "total_spent": "0.00",
+      "orders_count": "1",
+      "last_order_id": 450789469,
+      "tax_exemptions": {},
+      "verified_email": true,
+      "default_address": {},
+      "last_order_name": "#1001",
+      "accepts_marketing": false,
+      "admin_graphql_api_id": "gid://shopify/Customer/207119551",
+      "multipass_identifier": null
+    },
+    "customer_locale": "en-CA",
+    "discount_applications": {
+      "discount_applications": [
+        {
+          "type": "manual",
+          "title": "custom discount",
+          "value": "2.0",
+          "value_type": "fixed_amount",
+          "description": "customer deserved it",
+          "target_type": "line_item",
+          "target_selection": "explicit",
+          "allocation_method": "across"
+        },
+        {
+          "type": "script",
+          "value": "5.0",
+          "value_type": "fixed_amount",
+          "description": "my scripted discount",
+          "target_type": "shipping_line",
+          "target_selection": "explicit",
+          "allocation_method": "across"
+        },
+        {
+          "code": "SUMMERSALE",
+          "type": "discount_code",
+          "value": "10.0",
+          "value_type": "fixed_amount",
+          "target_type": "line_item",
+          "target_selection": "all",
+          "allocation_method": "across"
+        }
+      ]
+    },
+    "discount_codes": [
+      {
+        "code": "SPRING30",
+        "type": "fixed_amount",
+        "amount": "30.00"
+      }
+    ],
+    "email": "bob.norman@hostmail.com",
+    "estimated_taxes": false,
+    "financial_status": "authorized",
+    "fulfillments": [
+      {
+        "id": 255858046,
+        "status": "failure",
+        "order_id": 450789469,
+        "created_at": "2012-03-13T16:09:54-04:00",
+        "updated_at": "2012-05-01T14:22:25-04:00",
+        "tracking_number": "1Z2345",
+        "tracking_company": "USPS"
+      }
+    ],
+    "fulfillment_status": "partial",
+    "gateway": "shopify_payments",
+    "id": 450789469,
+    "landing_site": "http://www.example.com?source=abc",
+    "line_items": [
+      {
+        "id": 669751112,
+        "sku": "IPOD-342-N",
+        "name": "IPod Nano - Pink",
+        "grams": 500,
+        "price": "199.99",
+        "title": "IPod Nano",
+        "duties": [
+          {
+            "id": "2",
+            "tax_lines": [
+              {
+                "rate": 0.1,
+                "price": "16.486",
+                "title": "VAT",
+                "price_set": {
+                  "shop_money": {
+                    "amount": "16.486",
+                    "currency_code": "CAD"
+                  },
+                  "presentment_money": {
+                    "amount": "10.531",
+                    "currency_code": "EUR"
+                  }
+                },
+                "channel_liable": true
+              }
+            ],
+            "shop_money": {
+              "amount": "164.86",
+              "currency_code": "CAD"
+            },
+            "presentment_money": {
+              "amount": "105.31",
+              "currency_code": "EUR"
+            },
+            "admin_graphql_api_id": "gid://shopify/Duty/2",
+            "country_code_of_origin": "CA",
+            "harmonized_system_code": "520300"
+          }
+        ],
+        "vendor": "Apple",
+        "taxable": true,
+        "quantity": 1,
+        "gift_card": false,
+        "price_set": {
+          "shop_money": {
+            "amount": "199.99",
+            "currency_code": "USD"
+          },
+          "presentment_money": {
+            "amount": "173.30",
+            "currency_code": "EUR"
+          }
+        },
+        "tax_lines": [
+          {
+            "rate": 0.13,
+            "price": "25.81",
+            "title": "HST",
+            "price_set": {
+              "shop_money": {
+                "amount": "25.81",
+                "currency_code": "USD"
+              },
+              "presentment_money": {
+                "amount": "20.15",
+                "currency_code": "EUR"
+              }
+            },
+            "channel_liable": true
+          }
+        ],
+        "product_id": 7513594,
+        "properties": [
+          {
+            "name": "custom engraving",
+            "value": "Happy Birthday Mom!"
+          }
+        ],
+        "variant_id": 4264112,
+        "variant_title": "Pink",
+        "total_discount": "5.00",
+        "origin_location": {
+          "id": 1390592786454,
+          "zip": "V7Y 1G5",
+          "city": "Toronto",
+          "name": "Apple",
+          "address1": "700 West Georgia Street",
+          "address2": "1500",
+          "country_code": "CA",
+          "province_code": "ON"
+        },
+        "requires_shipping": true,
+        "fulfillment_status": "fulfilled",
+        "total_discount_set": {
+          "shop_money": {
+            "amount": "5.00",
+            "currency_code": "USD"
+          },
+          "presentment_money": {
+            "amount": "4.30",
+            "currency_code": "EUR"
+          }
+        },
+        "fulfillment_service": "amazon",
+        "discount_allocations": [
+          {
+            "amount": "5.00",
+            "amount_set": {
+              "shop_money": {
+                "amount": "5.00",
+                "currency_code": "USD"
+              },
+              "presentment_money": {
+                "amount": "3.96",
+                "currency_code": "EUR"
+              }
+            },
+            "discount_application_index": 2
+          }
+        ],
+        "fulfillable_quantity": 1
+      }
+    ],
+    "location_id": 49202758,
+    "name": "#1001",
+    "note": "Customer changed their mind.",
+    "note_attributes": [
+      {
+        "name": "custom name",
+        "value": "custom value"
+      }
+    ],
+    "number": 1,
+    "order_number": 1001,
+    "original_total_duties_set": {
+      "original_total_duties_set": {
+        "shop_money": {
+          "amount": "164.86",
+          "currency_code": "CAD"
+        },
+        "presentment_money": {
+          "amount": "105.31",
+          "currency_code": "EUR"
+        }
+      }
+    },
+    "payment_details": {
+      "avs_result_code": "Y",
+      "credit_card_bin": "453600",
+      "cvv_result_code": "M",
+      "credit_card_number": "•••• •••• •••• 4242",
+      "credit_card_company": "Visa"
+    },
+    "payment_terms": {
+      "amount": 70,
+      "currency": "CAD",
+      "due_in_days": 30,
+      "payment_schedules": [
+        {
+          "amount": 70,
+          "due_at": "2020-08-29T13:02:43-04:00",
+          "currency": "CAD",
+          "issued_at": "2020-07-29T13:02:43-04:00",
+          "completed_at": "null",
+          "expected_payment_method": "shopify_payments"
+        }
+      ],
+      "payment_terms_name": "NET_30",
+      "payment_terms_type": "NET"
+    },
+    "payment_gateway_names": [
+      "authorize_net",
+      "Cash on Delivery (COD)"
+    ],
+    "phone": "+557734881234",
+    "presentment_currency": "CAD",
+    "processed_at": "2008-01-10T11:00:00-05:00",
+    "processing_method": "direct",
+    "referring_site": "http://www.anexample.com",
+    "refunds": [
+      {
+        "id": 18423447608,
+        "note": null,
+        "user_id": null,
+        "order_id": 394481795128,
+        "created_at": "2018-03-06T09:35:37-05:00",
+        "processed_at": "2018-03-06T09:35:37-05:00",
+        "transactions": [],
+        "order_adjustments": [],
+        "refund_line_items": []
+      }
+    ],
+    "shipping_address": {
+      "zip": "K2P0V6",
+      "city": "Ottawa",
+      "name": "Bob Bobsen",
+      "phone": "555-625-1199",
+      "company": null,
+      "country": "Canada",
+      "address1": "123 Amoebobacterieae St",
+      "address2": "",
+      "latitude": "45.41634",
+      "province": "Ontario",
+      "last_name": "Bobsen",
+      "longitude": "-75.6868",
+      "first_name": "Bob",
+      "country_code": "CA",
+      "province_code": "ON"
+    },
+    "shipping_lines": [
+      {
+        "code": "INT.TP",
+        "price": "4.00",
+        "title": "Small Packet International Air",
+        "source": "canada_post",
+        "price_set": {
+          "shop_money": {
+            "amount": "4.00",
+            "currency_code": "USD"
+          },
+          "presentment_money": {
+            "amount": "3.17",
+            "currency_code": "EUR"
+          }
+        },
+        "tax_lines": [],
+        "discounted_price": "4.00",
+        "carrier_identifier": "third_party_carrier_identifier",
+        "discounted_price_set": {
+          "shop_money": {
+            "amount": "4.00",
+            "currency_code": "USD"
+          },
+          "presentment_money": {
+            "amount": "3.17",
+            "currency_code": "EUR"
+          }
+        },
+        "requested_fulfillment_service_id": "third_party_fulfillment_service_id"
+      }
+    ],
+    "source_name": "web",
+    "subtotal_price": 398,
+    "subtotal_price_set": {
+      "shop_money": {
+        "amount": "141.99",
+        "currency_code": "CAD"
+      },
+      "presentment_money": {
+        "amount": "90.95",
+        "currency_code": "EUR"
+      }
+    },
+    "tags": "imported, vip",
+    "tax_lines": [
+      {
+        "rate": 0.06,
+        "price": 11.94,
+        "title": "State Tax",
+        "channel_liable": true
+      }
+    ],
+    "taxes_included": false,
+    "test": true,
+    "token": "b1946ac92492d2347c6235b4d2611184",
+    "total_discounts": "0.00",
+    "total_discounts_set": {
+      "shop_money": {
+        "amount": "0.00",
+        "currency_code": "CAD"
+      },
+      "presentment_money": {
+        "amount": "0.00",
+        "currency_code": "EUR"
+      }
+    },
+    "total_line_items_price": "398.00",
+    "total_line_items_price_set": {
+      "shop_money": {
+        "amount": "141.99",
+        "currency_code": "CAD"
+      },
+      "presentment_money": {
+        "amount": "90.95",
+        "currency_code": "EUR"
+      }
+    },
+    "total_outstanding": "5.00",
+    "total_price": "409.94",
+    "total_price_set": {
+      "shop_money": {
+        "amount": "164.86",
+        "currency_code": "CAD"
+      },
+      "presentment_money": {
+        "amount": "105.31",
+        "currency_code": "EUR"
+      }
+    },
+    "total_shipping_price_set": {
+      "shop_money": {
+        "amount": "30.00",
+        "currency_code": "USD"
+      },
+      "presentment_money": {
+        "amount": "0.00",
+        "currency_code": "USD"
+      }
+    },
+    "total_tax": "11.94",
+    "total_tax_set": {
+      "shop_money": {
+        "amount": "18.87",
+        "currency_code": "CAD"
+      },
+      "presentment_money": {
+        "amount": "11.82",
+        "currency_code": "EUR"
+      }
+    },
+    "total_tip_received": "4.87",
+    "total_weight": 300,
+    "updated_at": "2012-08-24T14:02:15-04:00",
+    "user_id": 31522279,
+    "order_status_url": {
+      "order_status_url": "https://checkout.shopify.com/112233/checkouts/4207896aad57dfb159/thank_you_token?key=753621327b9e8a64789651bf221dfe35"
     }
   }
 }

--- a/schemas/shopify/webhooks/2022-01/Product.json
+++ b/schemas/shopify/webhooks/2022-01/Product.json
@@ -234,5 +234,70 @@
   },
   "required": [
     "title"
-  ]
+  ],
+  "default": {
+    "body_html": "It's the small iPod with a big idea: Video.",
+    "created_at": "2012-02-15T15:12:21-05:00",
+    "handle": "ipod-nano",
+    "id": 632910392,
+    "images": [
+      {
+        "id": 850703190,
+        "src": "http://example.com/burton.jpg",
+        "width": 110,
+        "height": 140,
+        "position": 1,
+        "created_at": "2018-01-08T12:34:47-05:00",
+        "product_id": 632910392,
+        "updated_at": "2018-01-08T12:34:47-05:00",
+        "variant_ids": []
+      }
+    ],
+    "options": {
+      "id": 594680422,
+      "name": "Color",
+      "values": [
+        "Pink",
+        "Red",
+        "Green",
+        "Black"
+      ],
+      "position": 1,
+      "product_id": 632910392
+    },
+    "product_type": "Cult Products",
+    "published_at": "2007-12-31T19:00:00-05:00",
+    "published_scope": "global",
+    "status": "active",
+    "tags": "Emotive, Flash Memory, MP3, Music",
+    "template_suffix": "special",
+    "title": "IPod Nano - 8GB",
+    "updated_at": "2012-08-24T14:01:47-04:00",
+    "variants": [
+      {
+        "id": 808950810,
+        "sku": "IPOD2008PINK",
+        "grams": 567,
+        "price": 199.99,
+        "title": "Pink",
+        "weight": 0.2,
+        "barcode": "1234_pink",
+        "option1": "Pink",
+        "taxable": true,
+        "position": 1,
+        "created_at": "2012-08-24T14:01:47-04:00",
+        "product_id": 632910392,
+        "updated_at": "2012-08-24T14:01:47-04:00",
+        "weight_unit": "kg",
+        "compare_at_price": null,
+        "inventory_policy": "continue",
+        "inventory_item_id": 341629,
+        "requires_shipping": true,
+        "inventory_quantity": 10,
+        "fulfillment_service": "manual",
+        "inventory_management": "shopify"
+      }
+    ],
+    "vendor": "Apple"
+  }
 }


### PR DESCRIPTION
Its weird that the validate step did not catch that the schemas didnt have a default.